### PR TITLE
feat(POC): initial support for tab notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +288,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
+ "async-attributes",
  "async-channel 1.9.0",
  "async-global-executor",
  "async-io 1.13.0",
@@ -3744,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee5e07b2425d3135e162740f99fe1594f43e5f0a62fe09e3002a8356c6a90cc"
+checksum = "58471198b62771e4387ac00c072e9b1d8ebd87db2568bdb5fbb60dd99d8552bd"
 dependencies = [
  "clap",
  "serde",
@@ -3758,18 +3769,18 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile-utils"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9a3ce2467ebf8784358b25d9063f72f97927b70edd5dbec596b5cef995f642"
+checksum = "6bde0479548039517e1ca6494ff2b7d1e365a9afd8335d794c67d12ce3cd1747"
 dependencies = [
  "ansi_term",
 ]
 
 [[package]]
 name = "zellij-utils"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b8f21edd42f679b1aa3440add0c6a6539f91d81c6eee5f41e105d84342c037"
+checksum = "5289f6ff643db4f7f772f090cede454cd1be276a3a5654464c402094b625524f"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1094,7 +1094,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1736,7 +1736,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2042,7 +2042,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2153,7 +2153,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2274,9 +2274,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.71"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2337,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2608,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -2627,20 +2627,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -2984,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.42"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3122,7 +3122,7 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3459,7 +3459,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -3493,7 +3493,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.42",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3834,6 +3834,8 @@ name = "zj-status-bar"
 version = "0.2.0"
 dependencies = [
  "ansi_term",
+ "serde",
+ "serde_json",
  "unicode-width",
  "zellij-tile",
  "zellij-tile-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ license = "MIT"
 [dependencies]
 ansi_term = "0.12"
 unicode-width = "0.1.8"
-zellij-tile = "0.39.2"
-zellij-tile-utils = "0.39.2"
+zellij-tile = "0.40.0"
+zellij-tile-utils = "0.40.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ ansi_term = "0.12"
 unicode-width = "0.1.8"
 zellij-tile = "0.40.0"
 zellij-tile-utils = "0.40.0"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"

--- a/src/line.rs
+++ b/src/line.rs
@@ -202,7 +202,11 @@ fn tab_line_prefix(
         })
     }
     let mode_part = format!("{:?}", mode).to_uppercase();
-    let mode_part_padded = format!("{:^mode_part_width$}", mode_part, mode_part_width = mode_part.width() + 2);
+    let mode_part_padded = format!(
+        "{:^mode_part_width$}",
+        mode_part,
+        mode_part_width = mode_part.width() + 2
+    );
     let mode_part_len = mode_part_padded.width();
     let mode_part_styled_text = if mode == InputMode::Locked {
         style!(locked_mode_color, bg_color)

--- a/src/line.rs
+++ b/src/line.rs
@@ -351,7 +351,7 @@ fn swap_layout_status(
                 "{}{}{}",
                 prefix_separator, swap_layout_name, suffix_separator
             );
-            let (part, full_len) = (format!("{}", swap_layout_indicator), swap_layout_name_len);
+            let (part, full_len) = (swap_layout_indicator.to_string(), swap_layout_name_len);
             let short_len = swap_layout_name_len + 1; // 1 is the space between
             if full_len <= max_len {
                 Some(LinePart {

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,8 +152,14 @@ impl ZellijPlugin for State {
                         pipe_message.args.get("pane_id"),
                         pipe_message.args.get("exit_code"),
                     ) {
-                        let pane_id: u32 = pane_id_str.parse().unwrap();
-                        let exit_code: u32 = exit_code_str.parse().unwrap();
+                        let pane_id: u32 = match pane_id_str.parse() {
+                            Ok(int) => int,
+                            Err(..) => return false,
+                        };
+                        let exit_code: u32 = match exit_code_str.parse() {
+                            Ok(int) => int,
+                            Err(..) => return false,
+                        };
 
                         for (tab_idx, pane_vec) in &self.pane_info.panes {
                             // skip panes in current tab

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ impl ZellijPlugin for State {
                 // would cause an infinite loop.
                 if !self.tab_alerts.is_empty() {
                     pipe_message_to_plugin(
-                        MessageToPlugin::new("zj-status-bar:process_status:broadcast")
+                        MessageToPlugin::new("zj-status-bar:plugin:tab_alert:broadcast")
                             .with_plugin_url("zellij:OWN_URL")
                             .with_payload(serde_json::to_string(&self.tab_alerts).unwrap()),
                     )
@@ -147,7 +147,7 @@ impl ZellijPlugin for State {
         let mut should_render = false;
         match pipe_message.source {
             PipeSource::Cli(_) => {
-                if pipe_message.name == "zj-status-bar:process_status" {
+                if pipe_message.name == "zj-status-bar:cli:tab_alert" {
                     if let (Some(pane_id_str), Some(exit_code_str)) = (
                         pipe_message.args.get("pane_id"),
                         pipe_message.args.get("exit_code"),
@@ -194,7 +194,7 @@ impl ZellijPlugin for State {
                 // Only read it if the current instance doesn't contain any info (new tab created
                 // after alerts were piped from a pane) to "catch up" and render them.
                 if pipe_message.is_private
-                    && pipe_message.name == "zj-status-bar:process_status:broadcast"
+                    && pipe_message.name == "zj-status-bar:plugin:tab_alert:broadcast"
                     && self.tab_alerts.is_empty()
                 {
                     self.tab_alerts = serde_json::from_str(&pipe_message.payload.unwrap()).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,7 @@ impl ZellijPlugin for State {
                     // tabs are indexed starting from 1 so we need to add 1
                     let active_tab_idx = active_tab_index + 1;
                     if self.active_tab_idx != active_tab_idx || self.tabs != tabs {
+                        self.tab_alerts.remove(&active_tab_index);
                         should_render = true;
                     }
                     self.active_tab_idx = active_tab_idx;
@@ -161,7 +162,7 @@ impl ZellijPlugin for State {
                             }
 
                             // find index of tab containing the pane
-                            if pane_vec.iter().find(|p| p.id == pane_id).is_some() {
+                            if pane_vec.iter().any(|p| p.id == pane_id) {
                                 let first_alert = self.tab_alerts.is_empty();
 
                                 self.tab_alerts.insert(
@@ -240,10 +241,6 @@ impl ZellijPlugin for State {
             if let Some(i) = self.tab_alerts.get(&t.position) {
                 alternate_color = i.alternate_color;
                 success = i.success;
-
-                if t.active {
-                    self.tab_alerts.remove(&t.position);
-                }
             }
 
             let tab = tab_style(

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,16 +77,12 @@ impl ZellijPlugin for State {
             Event::Timer(_) => {
                 // This timer is fired in the `pipe` lifecycle method and it's guaranteed there
                 // will be at least one alert.
-                let tab_alert_indexes = &self.tab_alerts.clone();
 
-                for (tab_idx, tab_alert) in tab_alert_indexes {
-                    self.tab_alerts.insert(
-                        *tab_idx,
-                        TabAlert {
-                            success: tab_alert.success,
-                            alternate_color: !tab_alert.alternate_color,
-                        },
-                    );
+                for tab_alert in self.tab_alerts.values_mut() {
+                    *tab_alert = TabAlert {
+                        success: tab_alert.success,
+                        alternate_color: !tab_alert.alternate_color,
+                    }
                 }
 
                 set_timeout(1.0);
@@ -158,13 +154,13 @@ impl ZellijPlugin for State {
                         let pane_id: u32 = pane_id_str.parse().unwrap();
                         let exit_code: u32 = exit_code_str.parse().unwrap();
 
-                        for (tab_idx, pane_vec) in &mut self.pane_info.panes {
+                        for (tab_idx, pane_vec) in &self.pane_info.panes {
                             // skip panes in current tab
                             if *tab_idx == self.active_tab_idx - 1 {
                                 continue;
                             }
 
-                            // find tab position containing the pane by its id.
+                            // find index of tab containing the pane
                             if pane_vec.iter().find(|p| p.id == pane_id).is_some() {
                                 let first_alert = self.tab_alerts.is_empty();
 
@@ -182,6 +178,9 @@ impl ZellijPlugin for State {
                                     set_timeout(1.0);
                                     should_render = true;
                                 }
+
+                                // tab index found, exit loop
+                                break;
                             }
                         }
                     }

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -17,7 +17,14 @@ fn cursors(focused_clients: &[ClientId], palette: Palette) -> (Vec<ANSIString>, 
     (cursors, len)
 }
 
-pub fn render_tab(text: String, tab: &TabInfo, palette: Palette, separator: &str, alternate_color: bool) -> LinePart {
+pub fn render_tab(
+    text: String,
+    tab: &TabInfo,
+    palette: Palette,
+    separator: &str,
+    alternate_color: bool,
+    success: bool,
+) -> LinePart {
     let focused_clients = tab.other_focused_clients.as_slice();
     let separator_width = separator.width();
     let background_color = if tab.active {
@@ -27,7 +34,11 @@ pub fn render_tab(text: String, tab: &TabInfo, palette: Palette, separator: &str
             palette.green
         }
     } else if alternate_color {
-        palette.red
+        if success {
+            palette.green
+        } else {
+            palette.red
+        }
     } else {
         palette.fg
     };
@@ -83,13 +94,14 @@ pub fn tab_style(
     palette: Palette,
     capabilities: PluginCapabilities,
     alternate_color: bool,
+    success: bool,
 ) -> LinePart {
     let separator = tab_separator(capabilities);
     if tab.is_sync_panes_active {
         tabname.push_str(" (Sync)");
     }
 
-    render_tab(tabname, tab, palette, separator, alternate_color)
+    render_tab(tabname, tab, palette, separator, alternate_color, success)
 }
 
 pub(crate) fn get_tab_to_focus(

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -17,7 +17,7 @@ fn cursors(focused_clients: &[ClientId], palette: Palette) -> (Vec<ANSIString>, 
     (cursors, len)
 }
 
-pub fn render_tab(text: String, tab: &TabInfo, palette: Palette, separator: &str) -> LinePart {
+pub fn render_tab(text: String, tab: &TabInfo, palette: Palette, separator: &str, alternate_color: bool) -> LinePart {
     let focused_clients = tab.other_focused_clients.as_slice();
     let separator_width = separator.width();
     let background_color = if tab.active {
@@ -26,6 +26,8 @@ pub fn render_tab(text: String, tab: &TabInfo, palette: Palette, separator: &str
         } else {
             palette.green
         }
+    } else if alternate_color {
+        palette.red
     } else {
         palette.fg
     };
@@ -80,13 +82,14 @@ pub fn tab_style(
     tab: &TabInfo,
     palette: Palette,
     capabilities: PluginCapabilities,
+    alternate_color: bool,
 ) -> LinePart {
     let separator = tab_separator(capabilities);
     if tab.is_sync_panes_active {
         tabname.push_str(" (Sync)");
     }
 
-    render_tab(tabname, tab, palette, separator)
+    render_tab(tabname, tab, palette, separator, alternate_color)
 }
 
 pub(crate) fn get_tab_to_focus(


### PR DESCRIPTION
initial POC for tab notifications.

### use-cases:

Notify finished processes on non-active tabs by start blinking on tab section.

I had this idea a few weeks ago when I had to run `gh pr checks` in watch mode in ~3 tabs at the morning, then forgot to check back for a few hours even when I had the tabs opened in the same session.

This POC uses zellij pipes to allow the status bar to receive data (currently the tab index, maybe it should accept exit status too?).
https://zellij.dev/documentation/plugin-pipes

### demo

send tab index via `zellij pipe`, the plugin will keep these in a hashmap and use timers to trigger a re-render every 1s.
The tab section will keep blinking until you visit it, then it's cleared internally from the hashmap.

[Screencast from 05-01-2024 06:13:43 PM.webm](https://github.com/cristiand391/zj-status-bar/assets/6853656/2aa4b4e1-eab9-4d56-b684-073a762930b7)

### side-notes
Thinking about the end UX... having to append `zellij pipe` to every command pane isn't good. I use mostly `zellij run --in-place` to do this
https://zellij.dev/documentation/zellij-run

explored creating a 2nd plugin that creates spawns command panes in-place but these don't emit the `RunCommandResult` event:
https://zellij.dev/documentation/plugin-api-events#runcommandresult

once the status bar POC is done I'll either re-create command panes using [`run_command`](https://zellij.dev/documentation/plugin-api-commands#run_command) or append something to the command pane names to be able to find them programatically.